### PR TITLE
Fix beacon length detection

### DIFF
--- a/disney_beacons_app.c
+++ b/disney_beacons_app.c
@@ -139,16 +139,12 @@ int32_t disney_beacons_app(void* args) {
     return 0;
 }
 
-void disney_beacons_app_update_state(DisneyBeaconsApp* app) {
+void disney_beacons_app_update_state(DisneyBeaconsApp* app, uint8_t beacon_data_len) {
     furi_hal_bt_extra_beacon_stop();
 
     furi_check(furi_hal_bt_extra_beacon_set_config(&app->beacon_config));
 
-    app->beacon_data_len = 0;
-    while((app->beacon_data[app->beacon_data_len] != 0) &&
-          (app->beacon_data_len < sizeof(app->beacon_data))) {
-        app->beacon_data_len++;
-    }
+    app->beacon_data_len = beacon_data_len;
 
     FURI_LOG_I(TAG, "beacon_data_len: %d", app->beacon_data_len);
 

--- a/disney_beacons_app.h
+++ b/disney_beacons_app.h
@@ -55,4 +55,4 @@ typedef enum {
     DisneyBeaconsAppCustomEventDataEditResult = 100,
 } DisneyBeaconsAppCustomEvent;
 
-void disney_beacons_app_update_state(DisneyBeaconsApp* app);
+void disney_beacons_app_update_state(DisneyBeaconsApp* app, uint8_t beacon_data_len);

--- a/scenes/scene_input_band_data.c
+++ b/scenes/scene_input_band_data.c
@@ -31,7 +31,7 @@ bool disney_beacons_app_scene_input_band_data_on_event(void* context, SceneManag
         if(event.event < band_menu_options_count) {
             const BandMenuOption* option = &band_menu_options[event.event];
             memcpy(ble_beacon->beacon_data, option->data, option->data_len);
-            disney_beacons_app_update_state(ble_beacon);
+            disney_beacons_app_update_state(ble_beacon, option->data_len);
             scene_manager_previous_scene(scene_manager);
             consumed = true;
         }

--- a/scenes/scene_input_beacon_data.c
+++ b/scenes/scene_input_beacon_data.c
@@ -27,7 +27,11 @@ bool disney_beacons_app_scene_input_beacon_data_on_event(void* context, SceneMan
 
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == DisneyBeaconsAppCustomEventDataEditResult) {
-            disney_beacons_app_update_state(ble_beacon);
+            uint8_t len = 0;
+            while((len < sizeof(ble_beacon->beacon_data)) && (ble_beacon->beacon_data[len] != 0)) {
+                len++;
+            }
+            disney_beacons_app_update_state(ble_beacon, len);
             scene_manager_previous_scene(scene_manager);
             return true;
         }

--- a/scenes/scene_input_ears_data.c
+++ b/scenes/scene_input_ears_data.c
@@ -47,7 +47,7 @@ bool disney_beacons_app_scene_input_ears_data_on_event(void* context, SceneManag
         if(event.event < ears_menu_options_count) {
             const EarsMenuOption* option = &ears_menu_options[event.event];
             memcpy(ble_beacon->beacon_data, option->data, option->data_len);
-            disney_beacons_app_update_state(ble_beacon);
+            disney_beacons_app_update_state(ble_beacon, option->data_len);
             scene_manager_previous_scene(scene_manager);
             consumed = true;
         }

--- a/scenes/scene_input_mac_addr.c
+++ b/scenes/scene_input_mac_addr.c
@@ -27,7 +27,7 @@ bool disney_beacons_app_scene_input_mac_addr_on_event(void* context, SceneManage
 
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == DisneyBeaconsAppCustomEventDataEditResult) {
-            disney_beacons_app_update_state(ble_beacon);
+            disney_beacons_app_update_state(ble_beacon, ble_beacon->beacon_data_len);
             scene_manager_previous_scene(scene_manager);
             return true;
         }

--- a/scenes/scene_run_beacon.c
+++ b/scenes/scene_run_beacon.c
@@ -65,7 +65,7 @@ bool disney_beacons_app_scene_run_beacon_on_event(void* context, SceneManagerEve
             return true;
         } else if(event.event == DialogExResultCenter) {
             ble_beacon->is_beacon_active = !ble_beacon->is_beacon_active;
-            disney_beacons_app_update_state(ble_beacon);
+            disney_beacons_app_update_state(ble_beacon, ble_beacon->beacon_data_len);
             update_status_text(ble_beacon);
             return true;
         }


### PR DESCRIPTION
## Summary
- pass beacon length to `disney_beacons_app_update_state`
- compute beacon length in beacon input scene
- update scenes that previously relied on 0 termination

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6869653dd2f88320baa92234cfb4b95e